### PR TITLE
nicolium: respect `with_replies` search param when selecting active tab

### DIFF
--- a/packages/nicolium/src/features/ui/router/index.tsx
+++ b/packages/nicolium/src/features/ui/router/index.tsx
@@ -145,6 +145,9 @@ const layouts = {
     getParentRoute: () => rootRoute,
     path: '/@{$username}',
     component: ProfileLayout,
+    validateSearch: v.object({
+      with_replies: v.optional(v.boolean()),
+    }),
   }),
   remoteInstance: createRoute({
     getParentRoute: () => rootRoute,

--- a/packages/nicolium/src/layouts/profile-layout.tsx
+++ b/packages/nicolium/src/layouts/profile-layout.tsx
@@ -26,6 +26,7 @@ import { LOCAL_STORAGE_REDIRECT_KEY } from '@/utils/redirect';
 /** Layout to display a user's profile. */
 const ProfileLayout: React.FC = () => {
   const { username } = layouts.profile.useParams();
+  const { with_replies: withReplies } = layouts.profile.useSearch();
   const location = useLocation();
 
   const { data: account, isUnauthorized } = useAccountLookup(username, true);
@@ -80,7 +81,7 @@ const ProfileLayout: React.FC = () => {
 
   let activeItem;
   const pathname = location.pathname.replace(`@${username}/`, '');
-  if (pathname.endsWith('/with_replies')) {
+  if (withReplies) {
     activeItem = 'replies';
   } else if (pathname.endsWith('/media')) {
     activeItem = 'media';


### PR DESCRIPTION
when `?with_replies=true` was present in the profile url, the profile page still highlighted the "Posts" tab because active tab selection only checked the pathname and ignored the search param